### PR TITLE
Autocomplete

### DIFF
--- a/src/main/java/net/staticcraft/setwarp/commands/PWarpCommand.java
+++ b/src/main/java/net/staticcraft/setwarp/commands/PWarpCommand.java
@@ -1,5 +1,7 @@
 package net.staticcraft.setwarp.commands;
 
+import java.util.ArrayList;
+import java.util.List;
 import net.staticcraft.setwarp.SetWarp;
 import net.staticcraft.setwarp.utils.FormattedStrings;
 import net.staticcraft.setwarp.utils.SetWarpUtils;
@@ -12,9 +14,32 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import java.util.logging.Level;
+import org.bukkit.command.TabCompleter;
 
-public class PWarpCommand implements CommandExecutor {
+public class PWarpCommand implements CommandExecutor, TabCompleter {
 
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command cmd, String label, String[] args) {
+        
+        if (!(sender instanceof Player)) {
+            SetWarp.getPlugin().getLogger().log(Level.WARNING, "Sorry, but only in-game players may use this command!");
+            return null;
+        }
+
+        Player player = (Player) sender;
+        
+        if (cmd.getName().equals("pwarp")) {
+            if (!player.hasPermission("setwarp.pwarp")) {
+                player.sendMessage(FormattedStrings.CHAT_ERROR_PREFIX() + FormattedStrings.PERMISSION_ERROR());
+                return null;
+            } else {
+                List<String> warpsList = SetWarpUtils.listWarpsAutocomplete((Player) player);
+                return warpsList;
+            }
+        }
+        return null;
+    }
+    
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
 

--- a/src/main/java/net/staticcraft/setwarp/commands/RemovePWarpCommand.java
+++ b/src/main/java/net/staticcraft/setwarp/commands/RemovePWarpCommand.java
@@ -1,5 +1,6 @@
 package net.staticcraft.setwarp.commands;
 
+import java.util.List;
 import net.staticcraft.setwarp.SetWarp;
 import net.staticcraft.setwarp.utils.FormattedStrings;
 import net.staticcraft.setwarp.utils.SetWarpUtils;
@@ -10,8 +11,31 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import java.util.logging.Level;
+import org.bukkit.command.TabCompleter;
 
-public class RemovePWarpCommand implements CommandExecutor {
+public class RemovePWarpCommand implements CommandExecutor, TabCompleter {
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command cmd, String label, String[] args) {
+        
+        if (!(sender instanceof Player)) {
+            SetWarp.getPlugin().getLogger().log(Level.WARNING, "Sorry, but only in-game players may use this command!");
+            return null;
+        }
+
+        Player player = (Player) sender;
+        
+        if (cmd.getName().equals("delpwarp")) {
+            if (!player.hasPermission("setwarp.delpwarp")) {
+                player.sendMessage(FormattedStrings.CHAT_ERROR_PREFIX() + FormattedStrings.PERMISSION_ERROR());
+                return null;
+            } else {
+                List<String> warpsList = SetWarpUtils.listWarpsAutocomplete((Player) player);
+                return warpsList;
+            }
+        }
+        return null;
+    }
 
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {

--- a/src/main/java/net/staticcraft/setwarp/utils/SetWarpUtils.java
+++ b/src/main/java/net/staticcraft/setwarp/utils/SetWarpUtils.java
@@ -32,7 +32,7 @@ public class SetWarpUtils {
 
         int size = data.getConfigurationSection("data").getKeys(false).size() - 1;
 
-        if (size < getMaxAllowedWarps(player)) {
+        if (size < getMaxAllowedWarps()) {
             data.set("data." + name.toLowerCase() + ".World", player.getLocation().getWorld().getName());
             data.set("data." + name.toLowerCase() + ".X", player.getLocation().getX());
             data.set("data." + name.toLowerCase() + ".Y", player.getLocation().getY());
@@ -42,7 +42,7 @@ public class SetWarpUtils {
             player.sendMessage(FormattedStrings.CHAT_SUCCESS_PREFIX() + FormattedStrings.SET_WARP_MESSAGE(name.toLowerCase()));
         } else {
             // print error to player.
-            player.sendMessage(FormattedStrings.CHAT_ERROR_PREFIX() + FormattedStrings.WARP_LIMIT_MESSAGE(getMaxAllowedWarps(player)));
+            player.sendMessage(FormattedStrings.CHAT_ERROR_PREFIX() + FormattedStrings.WARP_LIMIT_MESSAGE(getMaxAllowedWarps()));
         }
 
         try {
@@ -142,10 +142,7 @@ public class SetWarpUtils {
 
     }
 
-    public static int getMaxAllowedWarps(Player player) {
-        if(player.isOp()){
-            return 1024;
-        }
+    public static int getMaxAllowedWarps() {
         return SetWarp.getPlugin().getConfig().getInt("MAX_ALLOWED_WARPS");
     }
 

--- a/src/main/java/net/staticcraft/setwarp/utils/SetWarpUtils.java
+++ b/src/main/java/net/staticcraft/setwarp/utils/SetWarpUtils.java
@@ -9,6 +9,8 @@ import org.bukkit.entity.Player;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 public class SetWarpUtils {
@@ -30,7 +32,7 @@ public class SetWarpUtils {
 
         int size = data.getConfigurationSection("data").getKeys(false).size() - 1;
 
-        if (size < getMaxAllowedWarps()) {
+        if (size < getMaxAllowedWarps(player)) {
             data.set("data." + name.toLowerCase() + ".World", player.getLocation().getWorld().getName());
             data.set("data." + name.toLowerCase() + ".X", player.getLocation().getX());
             data.set("data." + name.toLowerCase() + ".Y", player.getLocation().getY());
@@ -40,7 +42,7 @@ public class SetWarpUtils {
             player.sendMessage(FormattedStrings.CHAT_SUCCESS_PREFIX() + FormattedStrings.SET_WARP_MESSAGE(name.toLowerCase()));
         } else {
             // print error to player.
-            player.sendMessage(FormattedStrings.CHAT_ERROR_PREFIX() + FormattedStrings.WARP_LIMIT_MESSAGE(getMaxAllowedWarps()));
+            player.sendMessage(FormattedStrings.CHAT_ERROR_PREFIX() + FormattedStrings.WARP_LIMIT_MESSAGE(getMaxAllowedWarps(player)));
         }
 
         try {
@@ -85,6 +87,26 @@ public class SetWarpUtils {
         }
     }
 
+    public static List<String> listWarpsAutocomplete(Player player) {
+
+        YamlConfiguration data = YamlConfiguration.loadConfiguration(getPlayerWarpsFile(player));
+
+        if (data.getConfigurationSection("data") != null) {
+            Set<String> warps = data.getConfigurationSection("data").getKeys(false);
+            warps.remove("account");
+            
+            List<String> warpsList = new ArrayList<>(warps);
+            if (!warpsList.isEmpty()) {
+                return warpsList;
+            } else {
+                player.sendMessage(FormattedStrings.CHAT_ERROR_PREFIX() + FormattedStrings.CREATE_WARP_HELP());
+            }
+        } else {
+            player.sendMessage(FormattedStrings.CHAT_ERROR_PREFIX() + FormattedStrings.NO_WARPS_ERROR());
+        }
+        return null;
+    }
+    
     public static void listPWarps(Player player) {
 
         YamlConfiguration data = YamlConfiguration.loadConfiguration(getPlayerWarpsFile(player));
@@ -120,7 +142,10 @@ public class SetWarpUtils {
 
     }
 
-    public static int getMaxAllowedWarps() {
+    public static int getMaxAllowedWarps(Player player) {
+        if(player.isOp()){
+            return 1024;
+        }
         return SetWarp.getPlugin().getConfig().getInt("MAX_ALLOWED_WARPS");
     }
 


### PR DESCRIPTION
add autocomplete for pwarp and delpwarp 
On tab it scroll through all warps available for the player, at the moment it doesn't consider the letter typed in.

For example:
Player's warps: {"desertVillage", "desertPyramid", "mesa", "coldOcean"};

> /pwarp 
on tab will scroll through all warps listed above

> /pwarp d
on tab will scroll through all warps listed above (not only "desertVillage" and "desertPyramid")

